### PR TITLE
Revert "kill homepod"

### DIFF
--- a/launch/graphviz-service.yml
+++ b/launch/graphviz-service.yml
@@ -16,6 +16,10 @@ dependencies: []
 team: eng-infra
 pod_config:
   group: us-west-1
+  prod:
+    migrationState: podOnly
+  dev:
+     migrationState: podOnly
 alarms:
 - type: InternalErrorAlarm
   severity: minor


### PR DESCRIPTION
Reverts Clever/graphviz-service#21

Dependency-failure-diagram-generator failed when talking with this in prod yesterday, rolling back to discoverable