### PR TITLE
remove alarm channel

### DIFF
--- a/launch/graphviz-service.yml
+++ b/launch/graphviz-service.yml
@@ -19,14 +19,12 @@ pod_config:
 alarms:
 - type: InternalErrorAlarm
   severity: minor
-  # channel: this will go to the channel that this team has configured in catapult for minor alarms
   parameters:
     threshold: 0.01
   extraParameters:
     source: Target
 - type: InternalErrorAlarm
   severity: major
-  # channel: this will go to the channel that this team has configured in catapult for major alarms
   parameters:
     threshold: 0.05
   extraParameters:

--- a/launch/graphviz-service.yml
+++ b/launch/graphviz-service.yml
@@ -4,7 +4,6 @@ env:
 - PORT
 resources:
   cpu: 0.25
-  soft_mem_limit: 0.2
   max_mem: 0.5
 expose:
 - name: http


### PR DESCRIPTION
Removing this deprecated "channel" field. Alarms will instead go to the default channel for your team.

Please confirm that this looks correct, and then merge it
