### PR TITLE
migrate services to app mesh in mesh_only state in dev

### DIFF
--- a/launch/graphviz-service.yml
+++ b/launch/graphviz-service.yml
@@ -43,3 +43,4 @@ mesh_config:
   dev:
     state: mesh_only
   crossRegionRoute: non-sso
+  setupInternalRoute: true


### PR DESCRIPTION
**JIRA:** https://clever.atlassian.net/browse/INFRANG-5113

**Overview:**
In this PR we will migrate all internal single region services in this repo to use app mesh in mesh_only state in DEV only. After this PR is merged the services will delete their loadbalancers. Going forward all the load balancing is done by envoy proxy.

An application in mesh can depend on any other application outside the mesh. But an application outside the mesh cannot depend on an application that is mesh_only.Engineers will still be able to access services using the usual URL but now we are going to share a single loadbalancer across all services!

Currently all apps are in hybrid mode which means that they are already using envoy for loadbalancing instead of using ALBs

**Rollout:**
- monitor cpu and memory

**Rollback:**
- ark rollback -e clever-dev <app>
- contact Tanmay or #oncall-infra