### PR TITLE
migrate services with some alb traffic to mesh_only

### DIFF
--- a/launch/graphviz-service.yml
+++ b/launch/graphviz-service.yml
@@ -45,4 +45,4 @@ mesh_config:
   crossRegionRoute: non-sso
   setupInternalRoute: true
   prod:
-    state: hybrid
+    state: mesh_only


### PR DESCRIPTION
**JIRA:** https://clever.atlassian.net/browse/INFRANG-5118

**Overview:**
This PR is part of the second cohort of apps that we are migrating from hybrid to mesh_only.

All apps in this cohort are receiving some amount of requests through their ALB which means they pose a higher risk than the previous cohort of apps.

If this app is receiving traffic via the ALB, double check that `setupInternalRoute` is set to true so that routes are setup for lambdas and other clients to access this service once it is mesh_only and ALBs are removed.

If `setupInternalRoute` is not set then check where the requests are coming from before adding it.

https://clever.grafana.net/d/Kyms8kdVz/applications-envoy-alb?orgId=1&from=now-2d&to=now

**Rollout:**
- monitor cpu and memory
- monitor envoy metrics

**Rollback:**
- ark rollback -e clever-dev <app>
- contact Tanmay or #oncall-infra
